### PR TITLE
Fix type check panic in socket call caused by incorrect box type

### DIFF
--- a/pkg/termux/sms.go
+++ b/pkg/termux/sms.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 )
 
-// SMSBoxType enumberates available sms box types
+// SMSBoxType enumerates available sms box types
 type SMSBoxType int
 
 const (
@@ -36,7 +36,7 @@ type SMS struct {
 func SMSList(limit int, offset int, box SMSBoxType) ([]SMS, error) {
 	buf := bytes.NewBuffer([]byte{})
 	if err := exec(nil, buf, "SmsInbox", map[string]interface{}{
-		"type":   box,
+		"type":   int(box),
 		"limit":  limit,
 		"offset": offset,
 	}, ""); err != nil {
@@ -47,7 +47,7 @@ func SMSList(limit int, offset int, box SMSBoxType) ([]SMS, error) {
 		return nil, err
 	}
 	l := make([]SMS, 0)
-	if err := json.Unmarshal(res, l); err != nil {
+	if err := json.Unmarshal(res, &l); err != nil {
 		return nil, err
 	}
 	return l, nil


### PR DESCRIPTION
Previously, a type check panic occurred during a socket call due to the incorrect use of the `termux.SMSBoxType` instead of the appropriate `box` type. This commit addresses this issue by correctly utilizing the required `box` type, resolving the type check panic.

Fixes #1